### PR TITLE
Optional model load on initialize

### DIFF
--- a/lib/smalltext.rb
+++ b/lib/smalltext.rb
@@ -15,7 +15,7 @@ module Smalltext
 
   class Classifier
 
-  	def initialize
+  	def initialize(synapse_file=nil)
   		@training_data = []
 
   		#organizing our data structures for documents , @categories, words
@@ -29,6 +29,8 @@ module Smalltext
 		@training=[]
 		@output=[]
 		@synapse = {}
+		
+		load_model(synapse_file) if synapse_file
   	end
 
   	def add_item(category, sentence)


### PR DESCRIPTION
Thanks for the gem! I'm using in a production app and it's been working fantastic.

I made this change to make it easier to load the classifier with a trained model and memoize in one step, eg:

```ruby
@classifier ||= Smalltext::Classifier.new("classifications.model")
```
It's a little cleaner to me than the version I put in [a blog post about Smalltext](https://dev.to/modsognir/ml-classification-on-short-strings-in-ruby-using-smalltext-5faa)

Thought i'd share the change in case you wanted it.

Thanks again!